### PR TITLE
Tell not to worry for detail URLs not working.

### DIFF
--- a/manuals/templates/step7.md
+++ b/manuals/templates/step7.md
@@ -17,6 +17,8 @@ First, let's bind the party details into our view:
 
 {{{diff_step 7.1}}}
 
+Notice that if you click on a party link in the list you get a correct detail page, but if you open the same destination URL in a new browser tab, you will not get the content.  This will be addressed in step 10 "Privacy & Subscriptions", section "Subscribe with Params".
+
 Now, let's change `party-details.component.html` into a form, so that we can edit the party details:
 
 {{{diff_step 7.2}}}


### PR DESCRIPTION
I notice that if you click on a party link in the list you get a correct detail page, but if you open the same destination URL in a new browser tab, you will not get the content.
Worrying that the whole scheme could be broken, I checked final app at step 22 and it had correct behavior.
I checked on further steps and noticed if was fixed in step 10 "Privacy & Subscriptions", section "Subscribe with Params".
Some other users of the tutorial will get worried, too, this change fixes that worry.
Thank you for your attention to details and tutorial quality.