### PR TITLE
`git clone` instead of `meteor create`

### DIFF
--- a/manuals/templates/step1.md
+++ b/manuals/templates/step1.md
@@ -20,7 +20,7 @@ Open your command line and paste this command:
 
 Now let's create our app — write this in the command line:
 
-    $ meteor create --example angular2-boilerplate socially
+    $ git clone https://github.com/bsliran/angular2-meteor-base socially
     
 > Alternatively, use your web browser to access the link:
 >


### PR DESCRIPTION
when running the  `meteor create` command it just prints the `git clone` command